### PR TITLE
Bugfix: Fails to build if x86_64-w64-mingw32-gcc cross-compiler on non-Windows

### DIFF
--- a/.ci/esy-build-steps.yml
+++ b/.ci/esy-build-steps.yml
@@ -11,4 +11,3 @@ steps:
     continueOnError: true
   - script: esy install
   - script: esy build
-  - script: esy b ./esy/test.sh

--- a/.ci/esy-build-steps.yml
+++ b/.ci/esy-build-steps.yml
@@ -11,3 +11,4 @@ steps:
     continueOnError: true
   - script: esy install
   - script: esy build
+  - script: esy b ./esy/test.sh

--- a/package.json
+++ b/package.json
@@ -7,8 +7,7 @@
     "build": [
         ["./esy/prep.sh"],
         ["bash", "-c", "#{os == 'windows' ? './esy/configure-windows.sh' : './esy/configure.sh'}"],
-        ["./esy/build.sh"],
-        ["./esy/test.sh"]
+        ["./esy/build.sh"]
     ],
     "buildsInSource": "_build",
     "exportedEnv": {


### PR DESCRIPTION
See esy-packages/esy-freetype2#10 - same issue.